### PR TITLE
Hotfix

### DIFF
--- a/myshell/parser.c
+++ b/myshell/parser.c
@@ -189,7 +189,7 @@ void free_struct_command(struct command * c) {
 
 void free_token_helper(struct token_helper * helper) {
     if(helper != NULL) {
-        free_file_struct(helper -> file);
+        // free_file_struct(helper -> file);
         free(helper);
     }
 }

--- a/myshell/parser.c
+++ b/myshell/parser.c
@@ -369,6 +369,7 @@ struct token_helper * tokenizeFile(char * buffer, size_t size, int index) {
     if(args_index == 0) {
         //no arguments; something weird happened
         printf("Args_index is 0\n");
+        free_file_struct(helper -> file);
         free_token_helper(helper);
         free(args);
         free(word);

--- a/myshell/test.c
+++ b/myshell/test.c
@@ -52,8 +52,9 @@ void test_override() {
     getcwd(cwd, sizeof(cwd));
 
     struct command * command = parse(cwd, buffer, length); //no need to free.. (causes double free)... why?
+    free(command);
 }
 int main(void) {
 
-    test_override();
+    test1();
 }


### PR DESCRIPTION
Fixed the issue with the returned struct command causing a double-free (we had freed files in the token helper, then passed those files into the command struct!)