### PR TITLE
Merged exec(2) branch

### DIFF
--- a/myshell/exec.c
+++ b/myshell/exec.c
@@ -129,6 +129,7 @@ void execute_pipe(struct file * file1, struct file * file2) {
         //Redirect STDOUT if file2 has an output other than STDOUT.
         int fd_out = STDOUT_FILENO;
         if(file2 -> output != NULL) {
+            printf("Program '%s' has output to file '%s'\n", file2->name, file2 -> output);
             fd_out = open(file2 -> output, O_WRONLY);
             if(fd_out < 0) {
                 perror("Could not open output file");
@@ -151,6 +152,7 @@ void execute_pipe(struct file * file1, struct file * file2) {
         //Redirect STDIN if file1 has an input other than STDOUT
         int fd_in = STDIN_FILENO;
         if(file1 -> input != NULL) {
+            printf("Program '%s' has input from file '%s'\n", file1->name, file1 -> input);
             fd_in = open(file2 -> input, O_RDONLY);
             if(fd_in < 0) {
                 perror("Could not open input file");
@@ -190,11 +192,12 @@ void exec_pipe(struct file * file1, struct file * file2) {
 }
 void execute_file(struct file * file) {
     //Redirect STDIN if file has an intput other than STDIN.
+
     int fd_in = STDIN_FILENO;
     if(file -> input != NULL) {
-        fd_in = open(file -> output, O_RDONLY);
+        fd_in = open(file -> input, O_RDONLY);
         if(fd_in < 0) {
-            perror("Could not open output file");
+            perror("Could not open input file");
             return;
         }
         dup2(fd_in, STDIN_FILENO); //designate fd_in as the same file descriptor as STDIN ; i.e., fd_in is now the intput file.


### PR DESCRIPTION
Redirection for one program works correctly; e.g. is as follows

input.txt > foo > output.txt

program foo will successfully have its input be from input.txt, and send its output to output.txt

Piping without redirection works correct; e.g. is as follows

example | foo

program "example" correctly sends its output to program "foo"

Piping with redirection does *not* work correctly; e.g. is as follows

input.txt > middle_man | foo

This results in relatively bizarre behavior. Try it and see!

input.txt > middle_man | foo > output.txt

Similar behavior as above, output.txt gets populated with junk / bizarre text.

example | foo > output.txt

output.txt does not receive any information.

What to do? Fix the file redirection when piping. Singular program works as expected, and handles input/output redirection.

